### PR TITLE
Move IO logic to user-space code (careful, not backward compatible!)

### DIFF
--- a/rust-competitive-helper-util/src/build.rs
+++ b/rust-competitive-helper-util/src/build.rs
@@ -1,4 +1,4 @@
-use crate::{read_lines, IOEnum, Task};
+use crate::{read_lines, Task};
 use std::collections::{HashMap, HashSet};
 
 const LIB_NAME: &str = "algo_lib";
@@ -355,7 +355,7 @@ fn add_rerun_if_changed_instructions() {
 
 pub fn build() {
     let all_macro = find_macro();
-    let (mut all_code, task) = find_usages_and_code(
+    let (mut all_code, _task) = find_usages_and_code(
         "src/main.rs",
         LIB_NAME,
         Vec::new(),
@@ -366,75 +366,7 @@ pub fn build() {
     all_code.sort();
     build_code(Vec::new(), all_code.as_mut_slice(), &mut code);
     code.push("fn main() {".to_string());
-    let task = task.unwrap();
-    match task.input.io_type {
-        IOEnum::StdIn | IOEnum::Regex => {
-            code.push("    let mut sin = std::io::stdin();".to_string());
-            if task.interactive {
-                code.push(
-                    "    let input = crate::io::input::Input::new_with_size(&mut sin, 1);"
-                        .to_string(),
-                );
-            } else {
-                code.push("    let input = crate::io::input::Input::new(&mut sin);".to_string());
-            }
-        }
-        IOEnum::File => {
-            code.push(format!(
-                "    let mut in_file = std::fs::File::open(\"{}\").unwrap();",
-                task.input.file_name.unwrap()
-            ));
-            if task.interactive {
-                code.push(
-                    "    let input = crate::io::input::Input::new_with_size(&mut in_file, 1);"
-                        .to_string(),
-                );
-            } else {
-                code.push(
-                    "    let input = crate::io::input::Input::new(&mut in_file);".to_string(),
-                );
-            }
-        }
-        _ => {
-            unreachable!()
-        }
-    }
-    match task.output.io_type {
-        IOEnum::StdOut => {
-            code.push("    unsafe {".to_string());
-            if task.interactive {
-                code.push(
-                    "        crate::io::output::OUTPUT = Some(crate::io::output::Output::new_with_auto_flush(Box::new(std::io::stdout())));".to_string()
-                );
-            } else {
-                code.push(
-                    "        crate::io::output::OUTPUT = Some(crate::io::output::Output::new(Box::new(std::io::stdout())));".to_string()
-                );
-            }
-            code.push("    }".to_string());
-        }
-        IOEnum::File => {
-            code.push(format!(
-                "    let out_file = std::fs::File::create(\"{}\").unwrap();",
-                task.output.file_name.unwrap()
-            ));
-            code.push("    unsafe {".to_string());
-            if task.interactive {
-                code.push(
-                    "        crate::io::output::OUTPUT = Some(crate::io::output::Output::new_with_auto_flush(Box::new(out_file)));".to_string()
-                );
-            } else {
-                code.push(
-                    "        crate::io::output::OUTPUT = Some(crate::io::output::Output::new(Box::new(out_file)));".to_string()
-                );
-            }
-            code.push("    }".to_string());
-        }
-        _ => {
-            unreachable!()
-        }
-    }
-    code.push("    crate::solution::run(input);".to_string());
+    code.push("    crate::solution::submit();".to_string());
     code.push("}".to_string());
     crate::write_lines("../main/src/main.rs", code);
     add_rerun_if_changed_instructions();

--- a/rust-competitive-helper-util/src/build.rs
+++ b/rust-competitive-helper-util/src/build.rs
@@ -1,4 +1,4 @@
-use crate::{read_lines, Task};
+use crate::read_lines;
 use std::collections::{HashMap, HashSet};
 
 const LIB_NAME: &str = "algo_lib";
@@ -187,17 +187,12 @@ fn find_usages_and_code(
     fqn_path: Vec<String>,
     processed: &mut HashSet<String>,
     all_macro: &HashMap<String, (String, Vec<String>)>,
-) -> (Vec<CodeFile>, Option<Task>) {
+) -> Vec<CodeFile> {
     let mut code = Vec::new();
     let mut all_code = Vec::new();
     let mut main = false;
-    let mut task = None;
 
     let mut lines = read_lines(file).into_iter();
-    if prefix == LIB_NAME {
-        let task_json = lines.next().unwrap().chars().skip(2).collect::<String>();
-        task = Some(serde_json::from_str::<Task>(task_json.as_str()).unwrap());
-    }
     while let Some(mut line) = lines.next() {
         if line.as_str() == "//START MAIN" {
             main = true;
@@ -226,7 +221,7 @@ fn find_usages_and_code(
                         for (file, fqn_path) in all {
                             if !processed.contains(&file) {
                                 processed.insert(file.clone());
-                                let (call_code, ..) = find_usages_and_code(
+                                let call_code = find_usages_and_code(
                                     file.as_str(),
                                     "crate",
                                     fqn_path,
@@ -252,7 +247,7 @@ fn find_usages_and_code(
         fqn: fqn_path,
     });
 
-    (all_code, task)
+    all_code
 }
 
 fn build_code(mut prefix: Vec<String>, mut to_add: &mut [CodeFile], code: &mut Vec<String>) {
@@ -355,7 +350,7 @@ fn add_rerun_if_changed_instructions() {
 
 pub fn build() {
     let all_macro = find_macro();
-    let (mut all_code, _task) = find_usages_and_code(
+    let mut all_code = find_usages_and_code(
         "src/main.rs",
         LIB_NAME,
         Vec::new(),


### PR DESCRIPTION
Instead of hardcoding way of creating `Input` and `Output`, we generate a simple `TaskIoSettings` structure, which contains information about what io should be used. 

Userspace code should handle it, and in runtime decide how to create `Input` and `Output` structs.

Now library expects solution to have `submit` function, which will be called in generated `main.rs`.

If somebody wants to use this version of helper, they need to update their templates a library code with roughly such diff:
https://github.com/rust-competitive-helper/example-contests-workspace/commit/b38ba13bf524ac53a564a3a7359695a1d711e27c

Library doesn't declare `TaskIoSettings` struct inside solution, and expects its definition to be present in `algo_lib`, so we don't need to have similar definitions in each solution file.

Misc: fixed bug with finding `$CARET` position. `main.find` returns index of byte, which previously didn't work well in case of non 1-byte chars.