### PR TITLE
specify group name when creating new task instead of "Manual"(default)

### DIFF
--- a/src/task_creator.rs
+++ b/src/task_creator.rs
@@ -142,9 +142,9 @@ pub fn create(task: Task) {
     }
 }
 
-fn select_name() -> String {
+fn select_name(prompt: &str) -> String {
     Input::with_theme(&ColorfulTheme::default())
-        .with_prompt("Task name:")
+        .with_prompt(format!("{} name:", prompt))
         .interact_on(&Term::stdout())
         .unwrap()
 }
@@ -227,10 +227,10 @@ fn select_output_type() -> IOType {
 }
 
 pub fn create_task_wizard() {
-    let name = select_name();
+    let name = select_name("Task");
     let task = Task {
         name: name.clone(),
-        group: "Manual".to_string(),
+        group: select_name("Group"),
         url: "".to_string(),
         interactive: false,
         time_limit: 2000,


### PR DESCRIPTION
Some sites don't support [Competitive Companion](https://github.com/jmerle/competitive-companion) and if you create your own tasks, its name is set to "Manual" by default, which is kind of messy if you have several custom tasks.

So in this pull request, you can specify group name for manually created task.